### PR TITLE
docs(codesigning): fixed major typo in code example

### DIFF
--- a/docs/CodeSigning.md
+++ b/docs/CodeSigning.md
@@ -26,7 +26,7 @@ In your `Fastfile`, add the following between your `sigh` and `gym` call:
 sigh
 
 # use the UID of the newly created provisioning profile
-ENV["PROFILE_UUID"] = lane_context[SharedValues::SIGH_UUID]
+ENV["PROFILE_UUID"] = lane_context[SharedValues::SIGH_UDID]
 
 gym(scheme: "Release")
 ```


### PR DESCRIPTION
I'm really glad you guys are working on this, it's an awesome tool.

This was a headache to find. actually UUID would be the right naming for that variable, but this fix is much needed.